### PR TITLE
Add visible upload controls and improve file picking

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,9 +17,15 @@
   </section>
   <aside class="controls-panel">
     <div class="controls-top">
-      <label class="file-btn mobile-file"> <input id="fileGallery" type="file" accept="image/*"> GALLERY </label>
-      <label class="file-btn mobile-file"> <input id="fileCamera" type="file" accept="image/*" capture="environment"> CAMERA </label>
-      <div id="dropzone" class="dropzone">DRAG HERE</div>
+      <label class="file-btn primary-file">
+        <input id="fileGallery" type="file" accept="image/*">
+        CARICA FILE
+      </label>
+      <label class="file-btn mobile-only">
+        <input id="fileCamera" type="file" accept="image/*" capture="environment">
+        CAMERA
+      </label>
+      <div id="dropzone" class="dropzone" tabindex="0">TRASCINA QUI O CLICCA PER CARICARE</div>
     </div>
     <div class="controls-body">
       <div class="field"><label>PIXEL SIZE</label><div class="slider"><input id="pixelSize" type="range" min="2" max="200" step="1" value="10"><input id="pixelSizeNum" class="num" type="number" min="2" max="200" step="1" value="10"></div></div>

--- a/src/app.js
+++ b/src/app.js
@@ -8,8 +8,18 @@ const el = {}; ids.forEach(id=>el[id]=$(id));
   const r=$(pair[0]), n=$(pair[1]); if(r&&n){ r.addEventListener('input',()=>{ n.value=r.value; fastRender(); }); n.addEventListener('input',()=>{ r.value=n.value; fastRender(); }); }
 });
 ['dither','invert','bg','fg','style','fmt','dpi','lockAR'].forEach(k=>{ const e=$(k); if(e) e.addEventListener('change',()=>fastRender()); });
-['fileGallery','fileCamera'].forEach(id=>{ const f=$(id); if(f) f.addEventListener('change', async e=>{ if(f.files && f.files[0]) await loadImageFile(f.files[0]); fastRender(); f.value=''; }); });
-const dropzone=document.getElementById('dropzone'); if(dropzone){ dropzone.addEventListener('dragover', e=>e.preventDefault()); dropzone.addEventListener('drop', async e=>{ e.preventDefault(); if(e.dataTransfer.files && e.dataTransfer.files[0]){ await loadImageFile(e.dataTransfer.files[0]); fastRender(); } }); }
+['fileGallery','fileCamera'].forEach(id=>{ const f=$(id); if(f) f.addEventListener('change', async ()=>{ if(f.files && f.files[0]) await loadImageFile(f.files[0]); fastRender(); f.value=''; }); });
+const dropzone=document.getElementById('dropzone');
+const galleryInput=$('fileGallery');
+if(dropzone){
+  const openPicker=()=>{ if(galleryInput) galleryInput.click(); };
+  dropzone.addEventListener('click', openPicker);
+  dropzone.addEventListener('keydown', e=>{ if(e.key==='Enter'||e.key===' '||e.key==='Spacebar'){ e.preventDefault(); openPicker(); } });
+  dropzone.addEventListener('dragenter', e=>{ e.preventDefault(); dropzone.classList.add('is-dragover'); });
+  dropzone.addEventListener('dragover', e=>{ e.preventDefault(); dropzone.classList.add('is-dragover'); if(e.dataTransfer) e.dataTransfer.dropEffect='copy'; });
+  dropzone.addEventListener('dragleave', e=>{ const rel=e.relatedTarget; if(!rel || !dropzone.contains(rel)) dropzone.classList.remove('is-dragover'); });
+  dropzone.addEventListener('drop', async e=>{ e.preventDefault(); dropzone.classList.remove('is-dragover'); if(e.dataTransfer.files && e.dataTransfer.files[0]){ await loadImageFile(e.dataTransfer.files[0]); fastRender(); } });
+}
 let img=null, lastSVG='', lastSize={w:800,h:400};
 const work=document.createElement('canvas'); const wctx=work.getContext('2d',{willReadFrequently:true});
 async function loadImageFile(file){ return new Promise(res=>{ const i=new Image(); i.onload=()=>{ img=i; res(); }; i.onerror=()=>{ res(); }; i.src=URL.createObjectURL(file); }); }

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,9 +8,15 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:
 .preview-box{width:100%;max-width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:#fff;border-right:1px solid var(--line);overflow:auto;padding:8px}
 #preview svg,#preview img{max-width:100%;height:auto;image-rendering:pixelated}
 .controls-panel{width:380px;border-left:1px solid var(--line);display:flex;flex-direction:column;gap:8px;padding:8px;background:#fff}
-.controls-top{display:none;gap:8px}
-.mobile-file{display:none}
-.dropzone{display:none}
+.controls-top{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:4px}
+.file-btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border:1px solid var(--line);border-radius:8px;font-weight:600;cursor:pointer;background:var(--bg);transition:background .2s,border-color .2s,color .2s;text-transform:uppercase;font-size:12px;letter-spacing:.06em}
+.file-btn:hover{background:#f0f0f0}
+.file-btn input{position:absolute;inset:0;opacity:0;cursor:pointer}
+.primary-file{min-width:160px}
+.mobile-only{display:none}
+.dropzone{flex:1 1 220px;display:flex;align-items:center;justify-content:center;border:1px dashed var(--line);padding:12px;border-radius:8px;text-align:center;font-weight:600;text-transform:uppercase;font-size:12px;letter-spacing:.06em;cursor:pointer;transition:background .2s,border-color .2s}
+.dropzone:hover,.dropzone:focus-visible{outline:none;background:#f0f0f0;border-color:#333}
+.dropzone.is-dragover{background:#e6f3ff;border-color:#1a73e8}
 .controls-body{overflow:auto;padding:4px;}
 .field{margin-bottom:10px;display:flex;flex-direction:column;gap:6px}
 .slider{display:flex;gap:8px;align-items:center}
@@ -23,9 +29,10 @@ hr{border:0;border-top:1px solid #eee;margin:8px 0}
   .layout{flex-direction:column}
   .controls-panel{width:100%;order:2;border-left:0;border-top:1px solid var(--line);padding:6px}
   .preview-area{order:1;padding:6px}
-  .controls-top{display:flex}
-  .mobile-file{display:inline-block}
-  .dropzone{display:block;border:1px dashed var(--line);padding:8px;border-radius:8px;text-align:center}
+  .controls-top{flex-direction:column;align-items:stretch;gap:10px}
+  .mobile-only{display:inline-flex}
+  .file-btn,.dropzone{width:100%}
+  .dropzone{padding:16px}
   .controls-body{display:flex;gap:8px;overflow-x:auto;padding:8px;flex-wrap:nowrap}
   .field{min-width:220px;flex:0 0 auto}
 }


### PR DESCRIPTION
## Summary
- expose the upload button and dropzone on desktop with refreshed styling
- make the dropzone clickable/keyboard-accessible and highlight drag interactions
- fix mobile file buttons by turning them into styled labels with hidden inputs

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e4b8c40940833295a38ff0d020a77f