### PR TITLE
Keep preview within viewport and compress uploads

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,9 +17,21 @@
   </section>
   <aside class="controls-panel">
     <div class="controls-top">
-      <label class="file-btn mobile-file"> <input id="fileGallery" type="file" accept="image/*"> GALLERY </label>
-      <label class="file-btn mobile-file"> <input id="fileCamera" type="file" accept="image/*" capture="environment"> CAMERA </label>
-      <div id="dropzone" class="dropzone">DRAG HERE</div>
+      <label class="file-btn primary-file">
+        <input id="fileGallery" type="file" accept="image/*">
+        CARICA FILE
+      </label>
+      <label class="file-btn mobile-only">
+        <input id="fileCamera" type="file" accept="image/*" capture="environment">
+        CAMERA
+      </label>
+      <div id="dropzone" class="dropzone" tabindex="0">TRASCINA QUI O CLICCA PER CARICARE</div>
+      <div class="upload-feedback" aria-live="polite">
+        <div id="uploadMessage" class="upload-message">NESSUN FILE CARICATO</div>
+        <div id="uploadProgressWrapper" class="upload-progress" hidden role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+          <div id="uploadProgressBar" class="progress-bar"></div>
+        </div>
+      </div>
     </div>
     <div class="controls-body">
       <div class="field"><label>PIXEL SIZE</label><div class="slider"><input id="pixelSize" type="range" min="2" max="200" step="1" value="10"><input id="pixelSizeNum" class="num" type="number" min="2" max="200" step="1" value="10"></div></div>

--- a/src/app.js
+++ b/src/app.js
@@ -1,22 +1,164 @@
 
 const $ = id => document.getElementById(id);
 const preview = $('preview'), meta = $('meta');
+const MAX_UPLOAD_DIMENSION = 800;
 const ids = ['pixelSize','pixelSizeNum','threshold','thresholdNum','blur','blurNum','blackPoint','blackPointNum','whitePoint','whitePointNum','gammaVal','gammaValNum','brightness','brightnessNum','contrast','contrastNum','style','thickness','thicknessNum','dither','invert','bg','fg','scale','scaleNum','fmt','dpi','outW','outH','lockAR','jpegQ','jpegQNum','rasterBG'];
 const el = {}; ids.forEach(id=>el[id]=$(id));
+const uploadMessage = $('uploadMessage');
+const progressWrap = $('uploadProgressWrapper');
+const progressBar = $('uploadProgressBar');
 // link sliders and numeric inputs
 [['pixelSize','pixelSizeNum'],['threshold','thresholdNum'],['blur','blurNum'],['blackPoint','blackPointNum'],['whitePoint','whitePointNum'],['gammaVal','gammaValNum'],['brightness','brightnessNum'],['contrast','contrastNum'],['thickness','thicknessNum'],['scale','scaleNum'],['jpegQ','jpegQNum']].forEach(pair=>{
   const r=$(pair[0]), n=$(pair[1]); if(r&&n){ r.addEventListener('input',()=>{ n.value=r.value; fastRender(); }); n.addEventListener('input',()=>{ r.value=n.value; fastRender(); }); }
 });
 ['dither','invert','bg','fg','style','fmt','dpi','lockAR'].forEach(k=>{ const e=$(k); if(e) e.addEventListener('change',()=>fastRender()); });
-['fileGallery','fileCamera'].forEach(id=>{ const f=$(id); if(f) f.addEventListener('change', async e=>{ if(f.files && f.files[0]) await loadImageFile(f.files[0]); fastRender(); f.value=''; }); });
-const dropzone=document.getElementById('dropzone'); if(dropzone){ dropzone.addEventListener('dragover', e=>e.preventDefault()); dropzone.addEventListener('drop', async e=>{ e.preventDefault(); if(e.dataTransfer.files && e.dataTransfer.files[0]){ await loadImageFile(e.dataTransfer.files[0]); fastRender(); } }); }
+['fileGallery','fileCamera'].forEach(id=>{
+  const f=$(id);
+  if(!f) return;
+  f.addEventListener('change', async ()=>{
+    if(f.files && f.files[0]) await handleFile(f.files[0]);
+    f.value='';
+  });
+});
+const dropzone=document.getElementById('dropzone');
+const galleryInput=$('fileGallery');
+if(dropzone){
+  const openPicker=()=>{ if(galleryInput) galleryInput.click(); };
+  dropzone.addEventListener('click', openPicker);
+  dropzone.addEventListener('keydown', e=>{ if(e.key==='Enter'||e.key===' '||e.key==='Spacebar'){ e.preventDefault(); openPicker(); } });
+  dropzone.addEventListener('dragenter', e=>{ e.preventDefault(); dropzone.classList.add('is-dragover'); });
+  dropzone.addEventListener('dragover', e=>{ e.preventDefault(); dropzone.classList.add('is-dragover'); if(e.dataTransfer) e.dataTransfer.dropEffect='copy'; });
+  dropzone.addEventListener('dragleave', e=>{ const rel=e.relatedTarget; if(!rel || !dropzone.contains(rel)) dropzone.classList.remove('is-dragover'); });
+  dropzone.addEventListener('drop', async e=>{
+    e.preventDefault();
+    dropzone.classList.remove('is-dragover');
+    if(e.dataTransfer.files && e.dataTransfer.files[0]){
+      await handleFile(e.dataTransfer.files[0]);
+    }
+  });
+}
 let img=null, lastSVG='', lastSize={w:800,h:400};
 const work=document.createElement('canvas'); const wctx=work.getContext('2d',{willReadFrequently:true});
-async function loadImageFile(file){ return new Promise(res=>{ const i=new Image(); i.onload=()=>{ img=i; res(); }; i.onerror=()=>{ res(); }; i.src=URL.createObjectURL(file); }); }
+function beginUpload(name=''){
+  if(uploadMessage) uploadMessage.textContent = name ? `Caricamento di ${name}...` : 'Caricamento in corso...';
+  if(progressWrap){
+    progressWrap.hidden = false;
+    progressWrap.removeAttribute('hidden');
+    progressWrap.classList.remove('is-indeterminate');
+    progressWrap.setAttribute('aria-valuenow','0');
+    progressWrap.setAttribute('aria-valuetext','0%');
+  }
+  if(progressBar) progressBar.style.width = '0%';
+}
+function updateUploadProgress(value){
+  if(!progressWrap || !progressBar) return;
+  progressWrap.classList.remove('is-indeterminate');
+  const pct = Math.max(0, Math.min(1, value||0));
+  progressBar.style.width = `${Math.round(pct*100)}%`;
+  const percentText = `${Math.round(pct*100)}%`;
+  progressWrap.setAttribute('aria-valuenow', String(Math.round(pct*100)));
+  progressWrap.setAttribute('aria-valuetext', percentText);
+}
+function setUploadIndeterminate(){
+  if(!progressWrap || !progressBar) return;
+  progressWrap.hidden = false;
+  progressWrap.removeAttribute('hidden');
+  progressWrap.classList.add('is-indeterminate');
+  progressBar.style.width = '40%';
+  progressWrap.removeAttribute('aria-valuenow');
+  progressWrap.setAttribute('aria-valuetext','Caricamento in corso');
+}
+function finishUpload(name=''){
+  if(progressWrap){
+    progressWrap.hidden = true;
+    progressWrap.classList.remove('is-indeterminate');
+    progressWrap.setAttribute('aria-valuenow','100');
+    progressWrap.setAttribute('aria-valuetext','Completato');
+  }
+  if(uploadMessage){
+    const dims = img ? ` (${img.naturalWidth}×${img.naturalHeight})` : '';
+    uploadMessage.textContent = name ? `File presente: ${name}${dims}` : `File presente${dims}`;
+  }
+}
+function uploadError(){
+  if(uploadMessage) uploadMessage.textContent = 'Errore durante il caricamento';
+  if(progressWrap){
+    progressWrap.hidden = true;
+    progressWrap.classList.remove('is-indeterminate');
+    progressWrap.setAttribute('aria-valuenow','0');
+    progressWrap.setAttribute('aria-valuetext','Errore');
+  }
+}
+async function handleFile(file){
+  if(!file) return;
+  beginUpload(file.name||'');
+  try{
+    await loadImageFile(file);
+    finishUpload(file.name||'');
+    fastRender();
+  }catch(err){
+    console.error(err);
+    uploadError();
+  }
+}
+async function loadImageFile(file){
+  return new Promise((resolve,reject)=>{
+    const reader = new FileReader();
+    reader.onprogress = e=>{
+      if(e.lengthComputable) updateUploadProgress(e.loaded/e.total);
+      else setUploadIndeterminate();
+    };
+    reader.onerror = ()=>{ reject(reader.error||new Error('Errore durante la lettura del file')); };
+    reader.onload = async ()=>{
+      const data = reader.result;
+      const i=new Image();
+      i.onload=async ()=>{
+        try{
+          const finalImg = await ensureMaxDimensions(i, MAX_UPLOAD_DIMENSION);
+          img = finalImg;
+          updateUploadProgress(1);
+          resolve();
+        }catch(err){
+          reject(err);
+        }
+      };
+      i.onerror=err=>{ reject(err||new Error('Impossibile caricare l\'immagine')); };
+      if(typeof data==='string') i.src=data; else reject(new Error('Formato file non supportato'));
+    };
+    try{ reader.readAsDataURL(file); }
+    catch(err){ reject(err); }
+  });
+}
+
+function ensureMaxDimensions(image, maxDim){
+  const maxSide = Math.max(image.naturalWidth, image.naturalHeight);
+  if(maxSide <= maxDim) return Promise.resolve(image);
+  const scale = maxDim / maxSide;
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.max(1, Math.round(image.naturalWidth * scale));
+  canvas.height = Math.max(1, Math.round(image.naturalHeight * scale));
+  const ctx = canvas.getContext('2d');
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = 'high';
+  ctx.drawImage(image,0,0,canvas.width,canvas.height);
+  const dataUrl = canvas.toDataURL('image/png');
+  return new Promise((resolve,reject)=>{
+    const resized = new Image();
+    resized.onload=()=>resolve(resized);
+    resized.onerror=err=>reject(err||new Error('Impossibile ridimensionare l\'immagine'));
+    resized.src=dataUrl;
+  });
+}
 
 // throttle with rAF for faster live preview
 let ticking=false;
 function fastRender(){ if(ticking) return; ticking=true; requestAnimationFrame(()=>{ generate(); ticking=false; }); }
+
+function clampInt(value, min, max){
+  const parsed = parseInt(value, 10);
+  if(Number.isNaN(parsed)) return min;
+  return Math.max(min, Math.min(max, parsed));
+}
 
 function generate(){
   try{
@@ -116,7 +258,52 @@ function buildASCII(gray,w,h,px,bg,fg,mode){
   svg+=`</g></svg>`; return svg;
 }
 
-function renderPreview(svg,scale=1){ preview.innerHTML=''; const wrapper=document.createElement('div'); wrapper.innerHTML=svg; const node=wrapper.firstChild; node.style.transformOrigin='top left'; node.style.transform=`scale(${scale})`; preview.appendChild(node); meta.textContent=`${lastSize.w}×${lastSize.h}px`; }
+function renderPreview(svg,scale=1){
+  if(!svg) return;
+  preview.innerHTML='';
+  const hostRect = preview.getBoundingClientRect();
+  const availableW = Math.max(1, preview.clientWidth || hostRect.width || lastSize.w);
+  const availableH = Math.max(1, preview.clientHeight || hostRect.height || lastSize.h);
+  const ratio = lastSize.h ? lastSize.w / lastSize.h : 1;
+  const userScale = Number.isFinite(scale) && scale>0 ? scale : 1;
+  let baseW = availableW;
+  let baseH = ratio ? baseW / ratio : availableH;
+  if(baseH > availableH){
+    baseH = availableH;
+    baseW = baseH * ratio;
+  }
+  const targetW = Math.min(baseW * userScale, availableW);
+  const targetH = Math.min(baseH * userScale, availableH);
+  const finalW = Math.max(1, Math.round(targetW));
+  const finalH = Math.max(1, Math.round(targetH));
+  const frame=document.createElement('div');
+  frame.className='preview-frame';
+  frame.style.width=`${finalW}px`;
+  frame.style.height=`${finalH}px`;
+  const wrapper=document.createElement('div');
+  wrapper.innerHTML=svg;
+  const node=wrapper.firstChild;
+  if(node){
+    node.setAttribute('width','100%');
+    node.setAttribute('height','100%');
+    node.setAttribute('preserveAspectRatio','xMidYMid meet');
+    node.style.width='100%';
+    node.style.height='100%';
+    frame.appendChild(node);
+  }
+  preview.appendChild(frame);
+  meta.textContent=`${lastSize.w}×${lastSize.h}px`;
+}
+
+let resizeRaf=null;
+window.addEventListener('resize',()=>{
+  if(!lastSVG) return;
+  if(resizeRaf) cancelAnimationFrame(resizeRaf);
+  resizeRaf=requestAnimationFrame(()=>{
+    resizeRaf=null;
+    renderPreview(lastSVG, parseFloat(el.scale.value||1));
+  });
+});
 
 // EXPORT (simple)
 document.getElementById('dlSVG').addEventListener('click', ()=>{ if(!lastSVG) return; const blob=new Blob([lastSVG],{type:'image/svg+xml'}); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='bitmap.svg'; a.click(); });

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,17 +1,31 @@
 
 :root{--bg:#fff;--fg:#000;--line:#000;--muted:#666}
 *{box-sizing:border-box}
-html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:JetBrains Mono,monospace}
+html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:JetBrains Mono,monospace;overflow:hidden}
 .topbar{height:56px;display:flex;align-items:center;padding:0 12px;border-bottom:1px solid var(--line);font-weight:700}
-.layout{display:flex;min-height:calc(100vh - 56px);gap:0}
-.preview-area{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;padding:8px}
-.preview-box{width:100%;max-width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:#fff;border-right:1px solid var(--line);overflow:auto;padding:8px}
-#preview svg,#preview img{max-width:100%;height:auto;image-rendering:pixelated}
-.controls-panel{width:380px;border-left:1px solid var(--line);display:flex;flex-direction:column;gap:8px;padding:8px;background:#fff}
-.controls-top{display:none;gap:8px}
-.mobile-file{display:none}
-.dropzone{display:none}
-.controls-body{overflow:auto;padding:4px;}
+.layout{display:flex;height:calc(100vh - 56px);gap:0;overflow:hidden}
+.preview-area{flex:1;display:flex;flex-direction:column;align-items:stretch;justify-content:flex-start;padding:8px;min-height:0;gap:8px}
+.preview-box{flex:1;min-height:0;width:100%;max-width:100%;display:flex;align-items:center;justify-content:center;background:#fff;border-right:1px solid var(--line);overflow:hidden;padding:8px}
+#preview .preview-frame{display:flex;align-items:center;justify-content:center;max-width:100%;max-height:100%;}
+#preview svg,#preview img{width:100%;height:100%;max-width:100%;max-height:100%;image-rendering:pixelated}
+.controls-panel{width:380px;border-left:1px solid var(--line);display:flex;flex-direction:column;gap:8px;padding:8px;background:#fff;min-height:0;overflow:hidden}
+.controls-top{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:4px}
+.file-btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border:1px solid var(--line);border-radius:8px;font-weight:600;cursor:pointer;background:var(--bg);transition:background .2s,border-color .2s,color .2s;text-transform:uppercase;font-size:12px;letter-spacing:.06em}
+.file-btn:hover{background:#f0f0f0}
+.file-btn input{position:absolute;inset:0;opacity:0;cursor:pointer}
+.primary-file{min-width:160px}
+.mobile-only{display:none}
+.dropzone{flex:1 1 220px;display:flex;align-items:center;justify-content:center;border:1px dashed var(--line);padding:12px;border-radius:8px;text-align:center;font-weight:600;text-transform:uppercase;font-size:12px;letter-spacing:.06em;cursor:pointer;transition:background .2s,border-color .2s}
+.dropzone:hover,.dropzone:focus-visible{outline:none;background:#f0f0f0;border-color:#333}
+.dropzone.is-dragover{background:#e6f3ff;border-color:#1a73e8}
+.upload-feedback{flex:1 1 100%;display:flex;flex-direction:column;gap:4px;font-size:11px;letter-spacing:.05em;text-transform:uppercase}
+.upload-message{font-weight:600;word-break:break-word}
+.upload-progress{position:relative;width:100%;height:6px;background:#e6e6e6;border-radius:999px;overflow:hidden}
+.upload-progress[hidden]{display:none}
+.upload-progress .progress-bar{position:absolute;inset:0 auto 0 0;height:100%;width:0;background:#1a73e8;transition:width .2s ease}
+.upload-progress.is-indeterminate .progress-bar{width:40%;animation:uploadPulse 1.2s infinite ease-in-out}
+@keyframes uploadPulse{0%{margin-left:-40%}50%{margin-left:20%}100%{margin-left:100%}}
+.controls-body{flex:1;overflow:auto;padding:4px;min-height:0}
 .field{margin-bottom:10px;display:flex;flex-direction:column;gap:6px}
 .slider{display:flex;gap:8px;align-items:center}
 .slider input[type='range']{flex:1;height:2px;background:#000;border-radius:4px}
@@ -21,11 +35,12 @@ hr{border:0;border-top:1px solid #eee;margin:8px 0}
 .muted{color:var(--muted);font-size:12px}
 @media (max-width:900px){
   .layout{flex-direction:column}
-  .controls-panel{width:100%;order:2;border-left:0;border-top:1px solid var(--line);padding:6px}
-  .preview-area{order:1;padding:6px}
-  .controls-top{display:flex}
-  .mobile-file{display:inline-block}
-  .dropzone{display:block;border:1px dashed var(--line);padding:8px;border-radius:8px;text-align:center}
-  .controls-body{display:flex;gap:8px;overflow-x:auto;padding:8px;flex-wrap:nowrap}
+  .controls-panel{width:100%;order:2;border-left:0;border-top:1px solid var(--line);padding:6px;flex:1 1 50%}
+  .preview-area{order:1;padding:6px;flex:1 1 50%}
+  .mobile-only{display:inline-flex}
+  .file-btn{width:100%}
+  .dropzone{display:none}
+  .upload-feedback{order:4;font-size:12px;text-transform:none;letter-spacing:0}
+  .controls-body{display:flex;gap:8px;overflow:auto;padding:8px;flex-wrap:nowrap}
   .field{min-width:220px;flex:0 0 auto}
 }


### PR DESCRIPTION
## Summary
- confine the preview canvas to the viewport with responsive sizing and resize-aware rendering so no scrolling is needed to view the UI
- downscale uploaded images to a maximum edge of 800px before processing and surface the resulting dimensions in the status message to keep the live preview fast
- lock the layout height and adjust panel scrolling rules so both desktop and mobile layouts stay within a single screen

## Testing
- Not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e4b8c40940833295a38ff0d020a77f