### PR TITLE
Add animation preview controls and stabilize exports

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,18 +13,34 @@
 <main class="layout">
   <section class="preview-area">
     <div id="preview" class="preview-box"></div>
-    <div id="meta" class="meta"></div>
+    <div class="preview-footer">
+      <div id="meta" class="meta"></div>
+      <button id="previewToggle" class="preview-toggle" type="button" hidden aria-hidden="true" aria-disabled="true">PAUSA ANTEPRIMA</button>
+    </div>
   </section>
   <aside class="controls-panel">
     <div class="controls-top">
-      <label class="file-btn mobile-file"> <input id="fileGallery" type="file" accept="image/*"> GALLERY </label>
-      <label class="file-btn mobile-file"> <input id="fileCamera" type="file" accept="image/*" capture="environment"> CAMERA </label>
-      <div id="dropzone" class="dropzone">DRAG HERE</div>
+      <label class="file-btn primary-file">
+        <input id="fileGallery" type="file" accept="image/*,video/mp4,image/gif">
+        CARICA FILE
+      </label>
+      <label class="file-btn mobile-only">
+        <input id="fileCamera" type="file" accept="image/*,video/mp4,image/gif" capture="environment">
+        CAMERA
+      </label>
+      <div id="dropzone" class="dropzone" tabindex="0">TRASCINA QUI O CLICCA PER CARICARE IMMAGINI, GIF O MP4</div>
+      <div class="upload-feedback" aria-live="polite">
+        <div id="uploadMessage" class="upload-message">NESSUN FILE CARICATO</div>
+        <div id="uploadProgressWrapper" class="upload-progress" hidden role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+          <div id="uploadProgressBar" class="progress-bar"></div>
+        </div>
+      </div>
     </div>
     <div class="controls-body">
       <div class="field"><label>PIXEL SIZE</label><div class="slider"><input id="pixelSize" type="range" min="2" max="200" step="1" value="10"><input id="pixelSizeNum" class="num" type="number" min="2" max="200" step="1" value="10"></div></div>
       <div class="field"><label>THRESHOLD</label><div class="slider"><input id="threshold" type="range" min="0" max="255" step="1" value="180"><input id="thresholdNum" class="num" type="number" min="0" max="255" step="1" value="180"></div></div>
       <div class="field"><label>BLUR</label><div class="slider"><input id="blur" type="range" min="0" max="30" step="0.5" value="0"><input id="blurNum" class="num" type="number" min="0" max="30" step="0.5" value="0"></div></div>
+      <div class="field"><label>GRAIN</label><div class="slider"><input id="grain" type="range" min="0" max="100" step="1" value="0"><input id="grainNum" class="num" type="number" min="0" max="100" step="1" value="0"></div></div>
 
       <div class="field"><label>BLACK POINT</label><div class="slider"><input id="blackPoint" type="range" min="0" max="255" step="1" value="0"><input id="blackPointNum" class="num" type="number" min="0" max="255" step="1" value="0"></div></div>
       <div class="field"><label>WHITE POINT</label><div class="slider"><input id="whitePoint" type="range" min="1" max="255" step="1" value="255"><input id="whitePointNum" class="num" type="number" min="1" max="255" step="1" value="255"></div></div>
@@ -52,7 +68,7 @@
       <div class="field"><label><input id="lockAR" type="checkbox" checked> LOCK ASPECT</label></div>
       <div class="field"><label>JPEG QUALITY</label><div class="slider"><input id="jpegQ" type="range" min="0.6" max="0.95" step="0.01" value="0.9"><input id="jpegQNum" class="num" type="number" min="0.6" max="0.95" step="0.01" value="0.9"></div></div>
       <div class="field"><label>RASTER BACKGROUND</label><input id="rasterBG" type="color" value="#ffffff"></div>
-      <div class="field"><div class="btn-row"><button id="dlSVG">DOWNLOAD SVG</button><button id="dlPNG">DOWNLOAD PNG</button><button id="dlJPG">DOWNLOAD JPEG</button></div><small class="muted">CAP: 3000 PX PER SIDE</small></div>
+      <div class="field"><div class="btn-row"><button id="dlSVG">DOWNLOAD SVG</button><button id="dlPNG">DOWNLOAD PNG</button><button id="dlJPG">DOWNLOAD JPEG</button></div><div class="btn-row"><button id="dlGIF" disabled>DOWNLOAD GIF</button><button id="dlMP4" disabled>DOWNLOAD MP4</button></div><small class="muted">CAP: 3000 PX PER SIDE</small></div>
     </div>
   </aside>
 </main>

--- a/src/app.js
+++ b/src/app.js
@@ -1,74 +1,875 @@
 
 const $ = id => document.getElementById(id);
 const preview = $('preview'), meta = $('meta');
-const ids = ['pixelSize','pixelSizeNum','threshold','thresholdNum','blur','blurNum','blackPoint','blackPointNum','whitePoint','whitePointNum','gammaVal','gammaValNum','brightness','brightnessNum','contrast','contrastNum','style','thickness','thicknessNum','dither','invert','bg','fg','scale','scaleNum','fmt','dpi','outW','outH','lockAR','jpegQ','jpegQNum','rasterBG'];
+const MAX_UPLOAD_DIMENSION = 800;
+const PREVIEW_MAX_DIMENSION = 360;
+const PREVIEW_TARGET_FPS = 8;
+const PREVIEW_MAX_FRAMES = 120;
+const ids = ['pixelSize','pixelSizeNum','threshold','thresholdNum','blur','blurNum','grain','grainNum','blackPoint','blackPointNum','whitePoint','whitePointNum','gammaVal','gammaValNum','brightness','brightnessNum','contrast','contrastNum','style','thickness','thicknessNum','dither','invert','bg','fg','scale','scaleNum','fmt','dpi','outW','outH','lockAR','jpegQ','jpegQNum','rasterBG'];
 const el = {}; ids.forEach(id=>el[id]=$(id));
+const uploadMessage = $('uploadMessage');
+const progressWrap = $('uploadProgressWrapper');
+const progressBar = $('uploadProgressBar');
+const previewToggle = $('previewToggle');
 // link sliders and numeric inputs
-[['pixelSize','pixelSizeNum'],['threshold','thresholdNum'],['blur','blurNum'],['blackPoint','blackPointNum'],['whitePoint','whitePointNum'],['gammaVal','gammaValNum'],['brightness','brightnessNum'],['contrast','contrastNum'],['thickness','thicknessNum'],['scale','scaleNum'],['jpegQ','jpegQNum']].forEach(pair=>{
+[['pixelSize','pixelSizeNum'],['threshold','thresholdNum'],['blur','blurNum'],['grain','grainNum'],['blackPoint','blackPointNum'],['whitePoint','whitePointNum'],['gammaVal','gammaValNum'],['brightness','brightnessNum'],['contrast','contrastNum'],['thickness','thicknessNum'],['scale','scaleNum'],['jpegQ','jpegQNum']].forEach(pair=>{
   const r=$(pair[0]), n=$(pair[1]); if(r&&n){ r.addEventListener('input',()=>{ n.value=r.value; fastRender(); }); n.addEventListener('input',()=>{ r.value=n.value; fastRender(); }); }
 });
 ['dither','invert','bg','fg','style','fmt','dpi','lockAR'].forEach(k=>{ const e=$(k); if(e) e.addEventListener('change',()=>fastRender()); });
-['fileGallery','fileCamera'].forEach(id=>{ const f=$(id); if(f) f.addEventListener('change', async e=>{ if(f.files && f.files[0]) await loadImageFile(f.files[0]); fastRender(); f.value=''; }); });
-const dropzone=document.getElementById('dropzone'); if(dropzone){ dropzone.addEventListener('dragover', e=>e.preventDefault()); dropzone.addEventListener('drop', async e=>{ e.preventDefault(); if(e.dataTransfer.files && e.dataTransfer.files[0]){ await loadImageFile(e.dataTransfer.files[0]); fastRender(); } }); }
-let img=null, lastSVG='', lastSize={w:800,h:400};
-const work=document.createElement('canvas'); const wctx=work.getContext('2d',{willReadFrequently:true});
-async function loadImageFile(file){ return new Promise(res=>{ const i=new Image(); i.onload=()=>{ img=i; res(); }; i.onerror=()=>{ res(); }; i.src=URL.createObjectURL(file); }); }
+['fileGallery','fileCamera'].forEach(id=>{
+  const f=$(id);
+  if(!f) return;
+  f.addEventListener('change', async ()=>{
+    if(f.files && f.files[0]) await handleFile(f.files[0]);
+    f.value='';
+  });
+});
+const dropzone=document.getElementById('dropzone');
+const galleryInput=$('fileGallery');
+if(dropzone){
+  const openPicker=()=>{ if(galleryInput) galleryInput.click(); };
+  dropzone.addEventListener('click', openPicker);
+  dropzone.addEventListener('keydown', e=>{ if(e.key==='Enter'||e.key===' '||e.key==='Spacebar'){ e.preventDefault(); openPicker(); } });
+  dropzone.addEventListener('dragenter', e=>{ e.preventDefault(); dropzone.classList.add('is-dragover'); });
+  dropzone.addEventListener('dragover', e=>{ e.preventDefault(); dropzone.classList.add('is-dragover'); if(e.dataTransfer) e.dataTransfer.dropEffect='copy'; });
+  dropzone.addEventListener('dragleave', e=>{ const rel=e.relatedTarget; if(!rel || !dropzone.contains(rel)) dropzone.classList.remove('is-dragover'); });
+  dropzone.addEventListener('drop', async e=>{
+    e.preventDefault();
+    dropzone.classList.remove('is-dragover');
+    if(e.dataTransfer.files && e.dataTransfer.files[0]){
+      await handleFile(e.dataTransfer.files[0]);
+    }
+  });
+}
+if(previewToggle){
+  previewToggle.addEventListener('click',()=>{
+    if(!lastAnimation || !lastAnimation.svgs || lastAnimation.svgs.length<=1) return;
+    setPreviewPlaying(!previewPlaying);
+  });
+}
+let mediaSource=null;
+let lastSVG='';
+let lastAnimation=null;
+let lastSize={w:800,h:400};
+const work=document.createElement('canvas');
+const wctx=work.getContext('2d',{willReadFrequently:true});
+const srcCanvas=document.createElement('canvas');
+const srcCtx=srcCanvas.getContext('2d',{willReadFrequently:true});
+let animationTimer=null;
+let animationFrameIndex=0;
+let previewPlaying=true;
+let currentPreviewAnimation=null;
+let currentPreviewDelays=[];
+let currentPreviewImage=null;
+let currentAnimationMetaBase='';
+
+function resetAnimationPreview(resetIndex=true){
+  if(animationTimer){
+    clearTimeout(animationTimer);
+    animationTimer=null;
+  }
+  if(resetIndex) animationFrameIndex=0;
+}
+function beginUpload(name=''){
+  if(uploadMessage) uploadMessage.textContent = name ? `Caricamento di ${name}...` : 'Caricamento in corso...';
+  if(progressWrap){
+    progressWrap.hidden = false;
+    progressWrap.removeAttribute('hidden');
+    progressWrap.classList.remove('is-indeterminate');
+    progressWrap.setAttribute('aria-valuenow','0');
+    progressWrap.setAttribute('aria-valuetext','0%');
+  }
+  if(progressBar) progressBar.style.width = '0%';
+}
+function updateUploadProgress(value){
+  if(!progressWrap || !progressBar) return;
+  progressWrap.classList.remove('is-indeterminate');
+  const pct = Math.max(0, Math.min(1, value||0));
+  progressBar.style.width = `${Math.round(pct*100)}%`;
+  const percentText = `${Math.round(pct*100)}%`;
+  progressWrap.setAttribute('aria-valuenow', String(Math.round(pct*100)));
+  progressWrap.setAttribute('aria-valuetext', percentText);
+}
+function setUploadIndeterminate(){
+  if(!progressWrap || !progressBar) return;
+  progressWrap.hidden = false;
+  progressWrap.removeAttribute('hidden');
+  progressWrap.classList.add('is-indeterminate');
+  progressBar.style.width = '40%';
+  progressWrap.removeAttribute('aria-valuenow');
+  progressWrap.setAttribute('aria-valuetext','Caricamento in corso');
+}
+function finishUpload(name=''){
+  if(progressWrap){
+    progressWrap.hidden = true;
+    progressWrap.classList.remove('is-indeterminate');
+    progressWrap.setAttribute('aria-valuenow','100');
+    progressWrap.setAttribute('aria-valuetext','Completato');
+  }
+  if(uploadMessage){
+    const dimsInfo = (mediaSource && mediaSource.width && mediaSource.height)
+      ? (()=>{
+          const base = `${mediaSource.width}×${mediaSource.height}`;
+          if(mediaSource.type==='animation' && mediaSource.frames){
+            const frames = mediaSource.frames.length;
+            const duration = mediaSource.duration ? ` · ${(mediaSource.duration/1000).toFixed(2)}s` : '';
+            return ` (${base}px · ${frames} fotogrammi${duration})`;
+          }
+          return ` (${base}px)`;
+        })()
+      : '';
+    uploadMessage.textContent = name ? `File presente: ${name}${dimsInfo}` : `File presente${dimsInfo}`;
+  }
+}
+function uploadError(){
+  if(uploadMessage) uploadMessage.textContent = 'Errore durante il caricamento';
+  if(progressWrap){
+    progressWrap.hidden = true;
+    progressWrap.classList.remove('is-indeterminate');
+    progressWrap.setAttribute('aria-valuenow','0');
+    progressWrap.setAttribute('aria-valuetext','Errore');
+  }
+}
+async function handleFile(file){
+  if(!file) return;
+  beginUpload(file.name||'');
+  try{
+    const type = (file.type||'').toLowerCase();
+    if(type.startsWith('video/') || /\.mp4$/i.test(file.name||'')){
+      await loadVideoFile(file);
+    }else if(type==='image/gif' || /\.gif$/i.test(file.name||'')){
+      await loadGifFile(file);
+    }else{
+      await loadImageFile(file);
+    }
+    finishUpload(file.name||'');
+    fastRender();
+  }catch(err){
+    console.error(err);
+    uploadError();
+  }
+}
+
+async function loadImageFile(file){
+  return new Promise((resolve,reject)=>{
+    const reader = new FileReader();
+    reader.onprogress = e=>{
+      if(e.lengthComputable) updateUploadProgress(e.loaded/e.total);
+      else setUploadIndeterminate();
+    };
+    reader.onerror = ()=>{ reject(reader.error||new Error('Errore durante la lettura del file')); };
+    reader.onload = async ()=>{
+      const data = reader.result;
+      const i=new Image();
+      i.onload=async ()=>{
+        try{
+          const finalCanvas = rasterizeImageToCanvas(i, MAX_UPLOAD_DIMENSION);
+          mediaSource = {
+            type:'image',
+            width: finalCanvas.width,
+            height: finalCanvas.height,
+            frames:[{canvas: finalCanvas, delay: 0}],
+            duration: 0,
+            preview: null
+          };
+          updateUploadProgress(1);
+          resolve();
+        }catch(err){
+          reject(err);
+        }
+      };
+      i.onerror=err=>{ reject(err||new Error('Impossibile caricare l\'immagine')); };
+      if(typeof data==='string') i.src=data; else reject(new Error('Formato file non supportato'));
+    };
+    try{ reader.readAsDataURL(file); }
+    catch(err){ reject(err); }
+  });
+}
+
+async function loadVideoFile(file){
+  const url = URL.createObjectURL(file);
+  try{
+    const video=document.createElement('video');
+    video.preload='auto';
+    video.playsInline=true;
+    video.muted=true;
+    video.src=url;
+    await once(video,'loadedmetadata');
+    if(video.readyState < 2){
+      try{ await once(video,'loadeddata'); }
+      catch(e){ /* ignore */ }
+    }
+    const framesData = await extractVideoFrames(video, MAX_UPLOAD_DIMENSION, progress=>updateUploadProgress(progress));
+    mediaSource={
+      type:'animation',
+      width: framesData.width,
+      height: framesData.height,
+      frames: framesData.frames,
+      duration: framesData.duration,
+      preview: buildPreviewAnimation(framesData.frames, framesData.width, framesData.height, framesData.duration)
+    };
+    updateUploadProgress(1);
+  }finally{
+    URL.revokeObjectURL(url);
+  }
+}
+
+async function loadGifFile(file){
+  if('ImageDecoder' in window){
+    const buffer = await file.arrayBuffer();
+    const type = file.type || 'image/gif';
+    const decoder = new ImageDecoder({data: buffer, type});
+    const track = decoder.tracks && decoder.tracks.length ? decoder.tracks[0] : null;
+    const frameCount = track ? track.frameCount : decoder.frameCount || 1;
+    const frames=[];
+    let totalDuration=0;
+    for(let i=0;i<frameCount;i++){
+      const {image} = await decoder.decode({frameIndex:i});
+      const dims = scaleDimensions(image.displayWidth||image.codedWidth||image.width, image.displayHeight||image.codedHeight||image.height, MAX_UPLOAD_DIMENSION);
+      const canvas=document.createElement('canvas');
+      canvas.width=dims.w;
+      canvas.height=dims.h;
+      const ctx=canvas.getContext('2d');
+      ctx.drawImage(image,0,0,dims.w,dims.h);
+      const delay = normalizeFrameDelay(image.duration);
+      frames.push({canvas, delay});
+      totalDuration += delay;
+      updateUploadProgress((i+1)/frameCount);
+      if(typeof image.close==='function') image.close();
+    }
+    const width = frames[0].canvas.width;
+    const height = frames[0].canvas.height;
+    mediaSource={
+      type:'animation',
+      width,
+      height,
+      frames,
+      duration: totalDuration,
+      preview: buildPreviewAnimation(frames, width, height, totalDuration)
+    };
+  }else{
+    await loadImageFile(file);
+  }
+}
+
+function scaleDimensions(width,height,maxDim){
+  const maxSide=Math.max(width,height);
+  if(maxSide<=maxDim) return {w:Math.max(1,Math.round(width)),h:Math.max(1,Math.round(height))};
+  const scale=maxDim/maxSide;
+  return {
+    w:Math.max(1,Math.round(width*scale)),
+    h:Math.max(1,Math.round(height*scale))
+  };
+}
+
+function rasterizeImageToCanvas(image, maxDim){
+  const dims=scaleDimensions(image.naturalWidth||image.width, image.naturalHeight||image.height, maxDim);
+  const canvas=document.createElement('canvas');
+  canvas.width=dims.w;
+  canvas.height=dims.h;
+  const ctx=canvas.getContext('2d');
+  ctx.imageSmoothingEnabled=true;
+  ctx.imageSmoothingQuality='high';
+  ctx.drawImage(image,0,0,dims.w,dims.h);
+  return canvas;
+}
+
+function cloneCanvas(source){
+  const canvas=document.createElement('canvas');
+  canvas.width=source.width;
+  canvas.height=source.height;
+  const ctx=canvas.getContext('2d');
+  ctx.drawImage(source,0,0);
+  return canvas;
+}
+
+async function extractVideoFrames(video, maxDim, progressCb){
+  const dims=scaleDimensions(video.videoWidth||video.width, video.videoHeight||video.height, maxDim);
+  const canvas=document.createElement('canvas');
+  canvas.width=dims.w;
+  canvas.height=dims.h;
+  const ctx=canvas.getContext('2d');
+  const fps=Math.max(1,Math.min(30,Math.round(video.frameRate||24)));
+  const duration=Number.isFinite(video.duration)?video.duration:0;
+  const totalFrames=duration?Math.max(1,Math.floor(duration*fps)):1;
+  const frames=[];
+  for(let i=0;i<totalFrames;i++){
+    const targetTime=duration?Math.min(duration, i/fps):0;
+    if(duration){
+      const needsSeek = Math.abs(video.currentTime - targetTime) > 1e-3;
+      if(needsSeek){
+        video.currentTime=targetTime;
+        await once(video,'seeked');
+      }
+    }
+    ctx.clearRect(0,0,dims.w,dims.h);
+    ctx.drawImage(video,0,0,dims.w,dims.h);
+    frames.push({canvas: cloneCanvas(canvas), delay: Math.max(10, Math.round(1000/fps))});
+    if(progressCb) progressCb((i+1)/totalFrames);
+  }
+  const totalDuration=frames.reduce((sum,f)=>sum+f.delay,0);
+  return {frames,width:dims.w,height:dims.h,duration:totalDuration};
+}
+
+function buildPreviewAnimation(frames,width,height,duration){
+  if(!frames || !frames.length){
+    return {frames:[], width:0, height:0, duration:0};
+  }
+  const dims=scaleDimensions(width,height,PREVIEW_MAX_DIMENSION);
+  const previewWidth=Math.max(1,dims.w);
+  const previewHeight=Math.max(1,dims.h);
+  const totalDuration = duration || frames.reduce((sum,f)=>sum+Math.max(10, f.delay||100),0);
+  const baseDelay=Math.max(80, Math.round(1000/Math.max(1, PREVIEW_TARGET_FPS)));
+  const countDelay = PREVIEW_MAX_FRAMES && totalDuration
+    ? Math.max(baseDelay, Math.round(totalDuration/Math.max(1, PREVIEW_MAX_FRAMES)))
+    : baseDelay;
+  const sampleDelay=Math.max(baseDelay, countDelay);
+  const previewFrames=[];
+  let elapsed=0;
+  let lastCaptured=0;
+  for(let i=0;i<frames.length;i++){
+    const frame=frames[i];
+    const delay=Math.max(10, frame.delay||100);
+    elapsed+=delay;
+    const isLast = i===frames.length-1;
+    if(!previewFrames.length || (elapsed-lastCaptured)>=sampleDelay || isLast){
+      const canvas=document.createElement('canvas');
+      canvas.width=previewWidth;
+      canvas.height=previewHeight;
+      const ctx=canvas.getContext('2d');
+      ctx.imageSmoothingEnabled=true;
+      ctx.imageSmoothingQuality='high';
+      ctx.drawImage(frame.canvas,0,0,previewWidth,previewHeight);
+      const diff=Math.max(0, Math.round(elapsed-lastCaptured));
+      const previewDelay = Math.max(sampleDelay, diff || sampleDelay);
+      previewFrames.push({canvas, delay: previewDelay});
+      lastCaptured=elapsed;
+    }
+  }
+  const previewDuration = previewFrames.reduce((sum,f)=>sum+Math.max(sampleDelay, f.delay||sampleDelay),0);
+  return {frames:previewFrames, width:previewWidth, height:previewHeight, duration:previewDuration};
+}
+
+function once(target,event){
+  return new Promise((resolve,reject)=>{
+    const cleanup=()=>{
+      target.removeEventListener(event,onEvent);
+      target.removeEventListener('error',onError);
+    };
+    const onEvent=()=>{ cleanup(); resolve(); };
+    const onError=()=>{ cleanup(); reject(target.error||new Error('Errore caricamento media')); };
+    target.addEventListener(event,onEvent);
+    target.addEventListener('error',onError);
+  });
+}
+
+function normalizeFrameDelay(raw){
+  if(!raw) return 100;
+  let value = raw;
+  if(value > 1000){
+    value = value/1000;
+  }else if(value < 1){
+    value = value*1000;
+  }
+  return Math.max(10, Math.round(value));
+}
+
+function updateExportButtons(){
+  const hasStatic = !!(lastSVG && lastSVG.length);
+  const hasAnimation = !!(lastAnimation && lastAnimation.svgs && lastAnimation.svgs.length);
+  ['dlSVG','dlPNG','dlJPG'].forEach(id=>{
+    const btn=$(id);
+    if(!btn) return;
+    const enabled = hasStatic || hasAnimation;
+    const busy = btn.dataset.busy === 'true';
+    btn.disabled = busy || !enabled;
+    btn.setAttribute('aria-disabled', (!enabled || busy) ? 'true' : 'false');
+    if(busy) btn.setAttribute('aria-busy','true');
+    else btn.removeAttribute('aria-busy');
+  });
+  ['dlGIF','dlMP4'].forEach(id=>{
+    const btn=$(id);
+    if(!btn) return;
+    const enabled = hasAnimation;
+    const busy = btn.dataset.busy === 'true';
+    btn.disabled = busy || !enabled;
+    btn.setAttribute('aria-disabled', (!enabled || busy) ? 'true' : 'false');
+    if(busy) btn.setAttribute('aria-busy','true');
+    else btn.removeAttribute('aria-busy');
+  });
+}
+
+function setButtonBusy(btn, busy, label){
+  if(!btn) return;
+  if(busy){
+    if(!btn.dataset.originalLabel) btn.dataset.originalLabel = btn.textContent;
+    if(label) btn.textContent = label;
+    btn.dataset.busy='true';
+    btn.disabled=true;
+    btn.setAttribute('aria-busy','true');
+    btn.setAttribute('aria-disabled','true');
+  }else{
+    if(btn.dataset.originalLabel) btn.textContent = btn.dataset.originalLabel;
+    delete btn.dataset.originalLabel;
+    delete btn.dataset.busy;
+    btn.removeAttribute('aria-busy');
+    btn.removeAttribute('aria-disabled');
+  }
+}
+
+async function runAnimationExport(button, busyLabel, work){
+  if(!button || button.dataset.busy === 'true') return null;
+  setButtonBusy(button, true, busyLabel);
+  updateExportButtons();
+  try{
+    return await work();
+  }catch(err){
+    console.error(err);
+    return null;
+  }finally{
+    setButtonBusy(button, false);
+    updateExportButtons();
+  }
+}
+
+function getExportDimensions(){
+  const baseW = (mediaSource && mediaSource.width) ? mediaSource.width : (lastSize.w || 1);
+  const baseH = (mediaSource && mediaSource.height) ? mediaSource.height : (lastSize.h || 1);
+  const aspect = baseH ? baseW / baseH : 1;
+  const maxSide = 3000;
+  let outW = parseInt(el.outW.value, 10);
+  let outH = parseInt(el.outH.value, 10);
+  if(Number.isNaN(outW)) outW = null;
+  if(Number.isNaN(outH)) outH = null;
+  const lock = el.lockAR ? el.lockAR.checked : true;
+  if(lock){
+    if(outW && !outH){
+      outH = Math.round(outW / aspect);
+    }else if(!outW && outH){
+      outW = Math.round(outH * aspect);
+    }else if(outW && outH){
+      outH = Math.round(outW / aspect);
+    }else{
+      outW = baseW;
+      outH = baseH;
+    }
+  }else{
+    if(!outW && !outH){
+      outW = baseW;
+      outH = baseH;
+    }else if(!outW){
+      outW = Math.round(outH * aspect);
+    }else if(!outH){
+      outH = Math.round(outW / aspect);
+    }
+  }
+  outW = Math.max(1, Math.min(maxSide, Math.round(outW || baseW)));
+  outH = Math.max(1, Math.min(maxSide, Math.round(outH || baseH)));
+  return {width: outW, height: outH};
+}
+
+function svgToCanvas(svg, width, height, background){
+  return new Promise((resolve,reject)=>{
+    const img=new Image();
+    img.onload=()=>{
+      const canvas=document.createElement('canvas');
+      canvas.width=width;
+      canvas.height=height;
+      const ctx=canvas.getContext('2d');
+      if(background){
+        ctx.fillStyle=background;
+        ctx.fillRect(0,0,width,height);
+      }else{
+        ctx.clearRect(0,0,width,height);
+      }
+      ctx.drawImage(img,0,0,width,height);
+      resolve(canvas);
+    };
+    img.onerror=()=>reject(new Error('Impossibile rasterizzare SVG'));
+    img.src='data:image/svg+xml;charset=utf-8,'+encodeURIComponent(svg);
+  });
+}
+
+function canvasToBlob(canvas, type, quality){
+  return new Promise((resolve,reject)=>{
+    canvas.toBlob(blob=>{
+      if(blob) resolve(blob);
+      else reject(new Error('Impossibile generare il file richiesto'));
+    }, type, quality);
+  });
+}
+
+function pushString(target,str){
+  for(let i=0;i<str.length;i++) target.push(str.charCodeAt(i) & 0xff);
+}
+
+function writeWord(target,value){
+  target.push(value & 0xff, (value>>8) & 0xff);
+}
+
+function buildPalette(imageDatas){
+  const map=new Map();
+  const palette=[];
+  for(const data of imageDatas){
+    const arr=data.data;
+    for(let i=0;i<arr.length;i+=4){
+      const a=arr[i+3];
+      if(a<5) continue;
+      const key=(arr[i]<<16)|(arr[i+1]<<8)|arr[i+2];
+      if(!map.has(key)){
+        if(palette.length===256) return {palette,map};
+        map.set(key,palette.length);
+        palette.push([arr[i],arr[i+1],arr[i+2]]);
+      }
+    }
+  }
+  if(palette.length===0){
+    palette.push([0,0,0]);
+    map.set(0,0);
+  }
+  return {palette,map};
+}
+
+function mapPixelsToIndices(imageData,paletteMap){
+  const arr=imageData.data;
+  const out=new Uint8Array(imageData.width*imageData.height);
+  for(let i=0,p=0;i<arr.length;i+=4,p++){
+    const key=(arr[i]<<16)|(arr[i+1]<<8)|arr[i+2];
+    const idx=paletteMap.has(key)?paletteMap.get(key):0;
+    out[p]=idx;
+  }
+  return out;
+}
+
+function lzwCompress(minCodeSize,data){
+  const clear = 1<<minCodeSize;
+  const end = clear+1;
+  let dict=new Map();
+  let dictSize;
+  let codeSize;
+  const reset=()=>{
+    dict=new Map();
+    for(let i=0;i<clear;i++) dict.set(i.toString(), i);
+    dictSize=end+1;
+    codeSize=minCodeSize+1;
+  };
+  reset();
+  const bytes=[];
+  let bitBuffer=0;
+  let bitCount=0;
+  const emit=code=>{
+    bitBuffer |= code << bitCount;
+    bitCount += codeSize;
+    while(bitCount>=8){
+      bytes.push(bitBuffer & 0xff);
+      bitBuffer >>=8;
+      bitCount -=8;
+    }
+  };
+  emit(clear);
+  if(!data || !data.length){
+    emit(end);
+    if(bitCount>0) bytes.push(bitBuffer & 0xff);
+    return bytes;
+  }
+  let prefix=data[0].toString();
+  for(let i=1;i<data.length;i++){
+    const k=data[i];
+    const key=prefix+','+k;
+    if(dict.has(key)){
+      prefix=key;
+    }else{
+      emit(dict.get(prefix));
+      if(dictSize<4096){
+        dict.set(key, dictSize++);
+        if(dictSize === (1<<codeSize) && codeSize<12){
+          codeSize++;
+        }
+      }else{
+        emit(clear);
+        reset();
+      }
+      prefix=k.toString();
+    }
+  }
+  emit(dict.get(prefix));
+  emit(end);
+  if(bitCount>0) bytes.push(bitBuffer & 0xff);
+  return bytes;
+}
+
+function buildAnimatedGIF(frames,width,height){
+  if(!frames.length) throw new Error('Nessun frame disponibile');
+  const imageDatas=frames.map(f=>f.data);
+  const delays=frames.map(f=>Math.max(10, f.delay||100));
+  const {palette,map}=buildPalette(imageDatas);
+  const paletteBits=Math.max(1, Math.ceil(Math.log2(Math.max(2, palette.length))));
+  const paletteSize=1<<paletteBits;
+  const paletteCopy=palette.slice();
+  while(paletteCopy.length<paletteSize){
+    const last=paletteCopy[paletteCopy.length-1]||[0,0,0];
+    paletteCopy.push(last.slice());
+  }
+  const indicesList=imageDatas.map(data=>mapPixelsToIndices(data,map));
+  const stream=[];
+  pushString(stream,'GIF89a');
+  writeWord(stream,width);
+  writeWord(stream,height);
+  const packed=0x80 | ((paletteBits-1)<<4) | (paletteBits-1);
+  stream.push(packed);
+  stream.push(0x00,0x00);
+  for(const color of paletteCopy){
+    stream.push(color[0],color[1],color[2]);
+  }
+  stream.push(0x21,0xFF,0x0B);
+  pushString(stream,'NETSCAPE2.0');
+  stream.push(0x03,0x01,0x00,0x00,0x00);
+  for(let i=0;i<indicesList.length;i++){
+    const delayUnits=Math.max(1, Math.round(delays[i]/10));
+    stream.push(0x21,0xF9,0x04,0x00, delayUnits & 0xff, (delayUnits>>8)&0xff, 0x00, 0x00);
+    stream.push(0x2C,0x00,0x00,0x00,0x00);
+    writeWord(stream,width);
+    writeWord(stream,height);
+    stream.push(0x00);
+    const minCodeSize=Math.max(2,paletteBits);
+    stream.push(minCodeSize);
+    const compressed=lzwCompress(minCodeSize, indicesList[i]);
+    let offset=0;
+    while(offset<compressed.length){
+      const block=Math.min(255, compressed.length-offset);
+      stream.push(block);
+      for(let b=0;b<block;b++) stream.push(compressed[offset+b]);
+      offset+=block;
+    }
+    stream.push(0x00);
+  }
+  stream.push(0x3B);
+  return new Blob([new Uint8Array(stream)], {type:'image/gif'});
+}
+
+async function exportAnimatedGIF(){
+  const {svgs, delays} = prepareAnimationExport();
+  if(!svgs.length) throw new Error('Nessuna animazione disponibile');
+  const dims=getExportDimensions();
+  const bg = el.rasterBG ? el.rasterBG.value : '#ffffff';
+  const frames=[];
+  for(let i=0;i<svgs.length;i++){
+    const canvas=await svgToCanvas(svgs[i],dims.width,dims.height,bg);
+    const ctx=canvas.getContext('2d');
+    frames.push({
+      data: ctx.getImageData(0,0,dims.width,dims.height),
+      delay: Math.max(10, delays[i]||delays[0]||100)
+    });
+    if(i%3===0) await wait(0);
+  }
+  return buildAnimatedGIF(frames,dims.width,dims.height);
+}
+
+async function recordSVGFramesToVideo(svgs, delays, width, height, background){
+  if(typeof MediaRecorder==='undefined') throw new Error('MediaRecorder non supportato dal browser');
+  const safeDelays=svgs.map((_,i)=>Math.max(16, delays[i]||delays[0]||100));
+  const avgDelay=safeDelays.reduce((sum,v)=>sum+v,0)/safeDelays.length;
+  const fps=Math.max(1, Math.min(30, Math.round(1000/Math.max(16, avgDelay))));
+  const frameInterval=Math.max(16, Math.round(1000/Math.max(1,fps)));
+  const canvas=document.createElement('canvas');
+  canvas.width=width;
+  canvas.height=height;
+  const ctx=canvas.getContext('2d');
+  const stream=canvas.captureStream(fps);
+  const mimeCandidates=['video/mp4;codecs=avc1.42E01E,mp4a.40.2','video/mp4;codecs=avc1.42E01E','video/mp4','video/webm;codecs=vp9','video/webm;codecs=vp8','video/webm'];
+  const mime=mimeCandidates.find(type=>MediaRecorder.isTypeSupported(type));
+  if(!mime) throw new Error('Nessun formato video supportato per l\'esportazione');
+  const recorder=new MediaRecorder(stream,{mimeType:mime, videoBitsPerSecond:4000000});
+  const chunks=[];
+  const stopped=new Promise((resolve,reject)=>{
+    recorder.onstop=resolve;
+    recorder.onerror=e=>reject(e.error||new Error('Registrazione video fallita'));
+  });
+  recorder.ondataavailable=e=>{ if(e.data && e.data.size) chunks.push(e.data); };
+  recorder.start();
+  let failure=null;
+  try{
+    for(let i=0;i<svgs.length;i++){
+      const raster=await svgToCanvas(svgs[i], width, height, background);
+      const repeats=Math.max(1, Math.round(safeDelays[i]/frameInterval));
+      for(let r=0;r<repeats;r++){
+        ctx.clearRect(0,0,width,height);
+        ctx.drawImage(raster,0,0,width,height);
+        await wait(frameInterval);
+      }
+      if(i%3===0) await wait(0);
+    }
+  }catch(err){
+    failure=err;
+  }
+  await wait(frameInterval*2);
+  if(recorder.state!=='inactive') recorder.stop();
+  try{
+    await stopped;
+  }catch(err){
+    if(!failure) failure=err;
+  }
+  if(failure) throw failure;
+  return {blob: new Blob(chunks,{type:mime}), mime};
+}
+
+async function exportAnimatedVideo(){
+  const {svgs, delays} = prepareAnimationExport();
+  if(!svgs.length) throw new Error('Nessuna animazione disponibile');
+  const dims=getExportDimensions();
+  const bg = el.rasterBG ? el.rasterBG.value : '#ffffff';
+  return recordSVGFramesToVideo(svgs, delays, dims.width, dims.height, bg);
+}
+
+function wait(ms){
+  return new Promise(resolve=>setTimeout(resolve, ms));
+}
+
+function triggerDownload(blob, filename){
+  const a=document.createElement('a');
+  a.href=URL.createObjectURL(blob);
+  a.download=filename;
+  a.click();
+  setTimeout(()=>URL.revokeObjectURL(a.href), 5000);
+}
 
 // throttle with rAF for faster live preview
 let ticking=false;
 function fastRender(){ if(ticking) return; ticking=true; requestAnimationFrame(()=>{ generate(); ticking=false; }); }
 
+function clampInt(value, min, max){
+  const parsed = parseInt(value, 10);
+  if(Number.isNaN(parsed)) return min;
+  return Math.max(min, Math.min(max, parsed));
+}
+
 function generate(){
   try{
-    const px = clampInt(el.pixelSize.value||10,2,200);
-    const thr = clampInt(el.threshold.value||180,0,255);
-    const blurPx = Math.max(0, parseFloat(el.blur.value||0));
-    const bp = clampInt(el.blackPoint.value||0,0,255);
-    const wp = clampInt(el.whitePoint.value||255,1,255);
-    const gam = Math.max(0.1, Math.min(3, parseFloat(el.gammaVal.value||1)));
-    const bri = Math.max(-100, Math.min(100, parseInt(el.brightness.value||'0',10)));
-    const con = Math.max(-100, Math.min(100, parseInt(el.contrast.value||'0',10)));
-    const style = el.style.value||'solid';
-    const thick = clampInt(el.thickness.value||2,1,6);
-    const mode = el.dither.value||'none';
-    const invertMode = el.invert.value||'auto';
-    const bg = el.bg.value||'#fff'; const fg = el.fg.value||'#000';
-
-    // source canvas
-    const src = document.createElement('canvas'); let sctx = src.getContext('2d');
-    if(img){ src.width = img.naturalWidth; src.height = img.naturalHeight; sctx.filter = blurPx>0?`blur(${blurPx}px)`:'none'; sctx.drawImage(img,0,0); sctx.filter='none'; }
-    else { src.width = 800; src.height = 400; sctx.fillStyle='#fff'; sctx.fillRect(0,0,src.width,src.height); sctx.fillStyle='#000'; sctx.font='700 140px JetBrains Mono'; sctx.fillText('Aa',20,160); }
-
-    const gridW = Math.max(1, Math.round(src.width/px)), gridH = Math.max(1, Math.round(src.height/px));
-    work.width = gridW; work.height = gridH; wctx.clearRect(0,0,gridW,gridH); wctx.drawImage(src,0,0,gridW,gridH);
-    const d = wctx.getImageData(0,0,gridW,gridH).data;
-    const gray = new Float32Array(gridW*gridH); let sum=0;
-    for(let i=0,p=0;i<d.length;i+=4,p++){ const l=0.299*d[i]+0.587*d[i+1]+0.114*d[i+2]; gray[p]=l; sum+=l; }
-    const avg = sum/(gridW*gridH);
-    // tonal mapping (black/white/gamma/brightness/contrast)
-    for(let p=0;p<gray.length;p++) gray[p]=applyTonal(gray[p], bp, wp, gam, bri, con);
-
-    let invert=false; if(invertMode==='yes') invert=true; else if(invertMode==='no') invert=false; else invert = avg>128;
-
-    let mask;
-    if(mode==='none') mask = thresholdMask(gray,gridW,gridH,thr,invert);
-    else if(mode.startsWith('ascii')) { /* handled below */ mask = null; }
-    else if(mode==='bayer4'||mode==='bayer8'||mode==='cross') mask = orderedDither(gray,gridW,gridH,thr,invert,mode);
-    else mask = errorDiffuse(gray,gridW,gridH,thr,invert,mode);
-
-    let outMask = mask;
-    if(style==='outline' && mask) outMask = boundary(mask,gridW,gridH,thick);
-    else if(style==='ring' && mask){ const dil=dilate(mask,gridW,gridH,thick), ero=erode(mask,gridW,gridH,thick); outMask=subtract(dil,ero); }
-
-    // ASCII modes
-    if(mode.startsWith('ascii')){
-      lastSVG = buildASCII(gray, gridW, gridH, px, bg, fg, mode);
-    } else {
-      lastSVG = buildSVG(outMask, gridW, gridH, px, bg, fg);
+    const options = collectRenderOptions();
+    const previewFrames = getPreviewFrames();
+    const hasAnimation = mediaSource && mediaSource.type==='animation' && previewFrames && previewFrames.length;
+    if(hasAnimation){
+      const {svgs,size} = renderFramesToSVGs(previewFrames, options);
+      const delays = getFrameDelays(previewFrames);
+      const previewInfo = mediaSource && mediaSource.preview;
+      const previewDuration = previewInfo && previewInfo.duration ? previewInfo.duration : sumDelays(delays);
+      const fullFrameCount = mediaSource && mediaSource.frames ? mediaSource.frames.length : 0;
+      const isLowQuality = !!(previewInfo && previewInfo.frames && previewInfo.frames.length && (
+        (previewInfo.width && mediaSource && mediaSource.width && previewInfo.width<mediaSource.width) ||
+        (previewInfo.height && mediaSource && mediaSource.height && previewInfo.height<mediaSource.height) ||
+        (fullFrameCount && previewInfo.frames.length < fullFrameCount)
+      ));
+      lastAnimation={svgs, delays, duration: previewDuration, lowQuality: isLowQuality};
+      lastSize=size;
+      lastSVG=svgs[0]||'';
+      renderAnimationPreview(lastAnimation, options.scale);
+    }else{
+      const frameCanvas = mediaSource && mediaSource.frames && mediaSource.frames.length ? mediaSource.frames[0].canvas : null;
+      const result = processFrame(frameCanvas, options);
+      lastSVG=result.svg;
+      lastSize=result.size;
+      lastAnimation=null;
+      renderStaticPreview(lastSVG, options.scale);
     }
-    lastSize = { w: Math.round(gridW*px), h: Math.round(gridH*px) };
-    renderPreview(lastSVG, parseFloat(el.scale.value||1));
+    updateExportButtons();
   }catch(e){ console.error(e); }
+}
+
+function collectRenderOptions(){
+  const px = clampInt(el.pixelSize.value||10,2,200);
+  const thr = clampInt(el.threshold.value||180,0,255);
+  const blurPx = Math.max(0, parseFloat(el.blur.value||0));
+  const grain = Math.max(0, Math.min(100, parseInt(el.grain.value||'0',10)));
+  const bp = clampInt(el.blackPoint.value||0,0,255);
+  const wp = clampInt(el.whitePoint.value||255,1,255);
+  const gam = Math.max(0.1, Math.min(3, parseFloat(el.gammaVal.value||1)));
+  const bri = Math.max(-100, Math.min(100, parseInt(el.brightness.value||'0',10)));
+  const con = Math.max(-100, Math.min(100, parseInt(el.contrast.value||'0',10)));
+  const style = el.style.value||'solid';
+  const thick = clampInt(el.thickness.value||2,1,6);
+  const mode = el.dither.value||'none';
+  const invertMode = el.invert.value||'auto';
+  const bg = el.bg.value||'#fff';
+  const fg = el.fg.value||'#000';
+  const scaleVal = parseFloat(el.scale.value||'1');
+  const scale = Number.isFinite(scaleVal) && scaleVal>0 ? scaleVal : 1;
+  return {px, thr, blurPx, grain, bp, wp, gam, bri, con, style, thick, mode, invertMode, bg, fg, scale};
+}
+
+function processFrame(frameCanvas, options){
+  const baseCanvas = frameCanvas || getPlaceholderCanvas();
+  srcCanvas.width = baseCanvas.width;
+  srcCanvas.height = baseCanvas.height;
+  srcCtx.setTransform(1,0,0,1,0,0);
+  srcCtx.clearRect(0,0,srcCanvas.width,srcCanvas.height);
+  if(options.blurPx>0){
+    srcCtx.filter=`blur(${options.blurPx}px)`;
+  }
+  srcCtx.drawImage(baseCanvas,0,0,srcCanvas.width,srcCanvas.height);
+  if(options.blurPx>0) srcCtx.filter='none';
+
+  const gridW = Math.max(1, Math.round(srcCanvas.width/options.px));
+  const gridH = Math.max(1, Math.round(srcCanvas.height/options.px));
+  work.width = gridW;
+  work.height = gridH;
+  wctx.clearRect(0,0,gridW,gridH);
+  wctx.drawImage(srcCanvas,0,0,gridW,gridH);
+  const d = wctx.getImageData(0,0,gridW,gridH).data;
+  const gray = new Float32Array(gridW*gridH); let sum=0;
+  const grainAmount = Math.max(0, options.grain||0);
+  for(let i=0,p=0;i<d.length;i+=4,p++){
+    let l=0.299*d[i]+0.587*d[i+1]+0.114*d[i+2];
+    if(grainAmount>0){
+      const noise=(Math.random()-0.5)*2*grainAmount;
+      l = Math.max(0, Math.min(255, l + noise));
+    }
+    gray[p]=l;
+    sum+=l;
+  }
+  const avg = sum/(gridW*gridH);
+  for(let p=0;p<gray.length;p++) gray[p]=applyTonal(gray[p], options.bp, options.wp, options.gam, options.bri, options.con);
+
+  let invert=false;
+  if(options.invertMode==='yes') invert=true;
+  else if(options.invertMode==='no') invert=false;
+  else invert = avg>128;
+
+  let mask;
+  if(options.mode==='none') mask = thresholdMask(gray,gridW,gridH,options.thr,invert);
+  else if(options.mode.startsWith('ascii')) mask=null;
+  else if(options.mode==='bayer4'||options.mode==='bayer8'||options.mode==='cross') mask = orderedDither(gray,gridW,gridH,options.thr,invert,options.mode);
+  else mask = errorDiffuse(gray,gridW,gridH,options.thr,invert,options.mode);
+
+  let svg;
+  if(options.mode.startsWith('ascii')){
+    svg = buildASCII(gray, gridW, gridH, options.px, options.bg, options.fg, options.mode);
+  }else{
+    let outMask = mask;
+    if(options.style==='outline' && mask) outMask = boundary(mask,gridW,gridH,options.thick);
+    else if(options.style==='ring' && mask){
+      const dil=dilate(mask,gridW,gridH,options.thick);
+      const ero=erode(mask,gridW,gridH,options.thick);
+      outMask=subtract(dil,ero);
+    }
+    svg = buildSVG(outMask, gridW, gridH, options.px, options.bg, options.fg);
+  }
+  return {svg, size:{w: Math.round(gridW*options.px), h: Math.round(gridH*options.px)}};
+}
+
+let placeholderCanvas=null;
+function getPlaceholderCanvas(){
+  if(!placeholderCanvas){
+    placeholderCanvas=document.createElement('canvas');
+    placeholderCanvas.width=800;
+    placeholderCanvas.height=400;
+    const ctx=placeholderCanvas.getContext('2d');
+    ctx.fillStyle='#ffffff';
+    ctx.fillRect(0,0,placeholderCanvas.width,placeholderCanvas.height);
+    ctx.fillStyle='#000000';
+    ctx.font='700 140px "JetBrains Mono", monospace';
+    ctx.fillText('Aa',20,160);
+  }
+  return placeholderCanvas;
 }
 
 function applyTonal(l,bp,wp,gamma,bright,contrast){
@@ -116,12 +917,297 @@ function buildASCII(gray,w,h,px,bg,fg,mode){
   svg+=`</g></svg>`; return svg;
 }
 
-function renderPreview(svg,scale=1){ preview.innerHTML=''; const wrapper=document.createElement('div'); wrapper.innerHTML=svg; const node=wrapper.firstChild; node.style.transformOrigin='top left'; node.style.transform=`scale(${scale})`; preview.appendChild(node); meta.textContent=`${lastSize.w}×${lastSize.h}px`; }
+function computePreviewSize(scale){
+  const hostRect = preview.getBoundingClientRect();
+  const availableW = Math.max(1, preview.clientWidth || hostRect.width || lastSize.w);
+  const availableH = Math.max(1, preview.clientHeight || hostRect.height || lastSize.h);
+  const ratio = lastSize.h ? lastSize.w / lastSize.h : 1;
+  const userScale = Number.isFinite(scale) && scale>0 ? scale : 1;
+  let baseW = availableW;
+  let baseH = ratio ? baseW / ratio : availableH;
+  if(baseH > availableH){
+    baseH = availableH;
+    baseW = baseH * ratio;
+  }
+  const targetW = Math.min(baseW * userScale, availableW);
+  const targetH = Math.min(baseH * userScale, availableH);
+  return {
+    width: Math.max(1, Math.round(targetW)),
+    height: Math.max(1, Math.round(targetH))
+  };
+}
 
-// EXPORT (simple)
-document.getElementById('dlSVG').addEventListener('click', ()=>{ if(!lastSVG) return; const blob=new Blob([lastSVG],{type:'image/svg+xml'}); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='bitmap.svg'; a.click(); });
-document.getElementById('dlPNG').addEventListener('click', ()=>{ if(!lastSVG) return; const img=new Image(); img.onload=()=>{ const c=document.createElement('canvas'); c.width=lastSize.w; c.height=lastSize.h; const cx=c.getContext('2d'); cx.fillStyle=el.rasterBG.value||'#fff'; cx.fillRect(0,0,c.width,c.height); cx.drawImage(img,0,0); c.toBlob(b=>{ const a=document.createElement('a'); a.href=URL.createObjectURL(b); a.download='bitmap.png'; a.click(); }); }; img.src='data:image/svg+xml;charset=utf-8,'+encodeURIComponent(lastSVG); });
-document.getElementById('dlJPG').addEventListener('click', ()=>{ if(!lastSVG) return; const img=new Image(); img.onload=()=>{ const c=document.createElement('canvas'); c.width=lastSize.w; c.height=lastSize.h; const cx=c.getContext('2d'); cx.fillStyle=el.rasterBG.value||'#fff'; cx.fillRect(0,0,c.width,c.height); cx.drawImage(img,0,0); c.toBlob(b=>{ const a=document.createElement('a'); a.href=URL.createObjectURL(b); a.download='bitmap.jpg'; a.click(); }, 'image/jpeg', parseFloat(el.jpegQ.value||0.9)); }; img.src='data:image/svg+xml;charset=utf-8,'+encodeURIComponent(lastSVG); });
+function renderStaticPreview(svg, scale=1){
+  resetAnimationPreview();
+  currentPreviewAnimation=null;
+  currentPreviewImage=null;
+  currentPreviewDelays=[];
+  preview.innerHTML='';
+  if(!svg){
+    currentAnimationMetaBase='';
+    if(meta) meta.textContent='';
+    updatePreviewToggle();
+    return;
+  }
+  const size = computePreviewSize(scale);
+  const frame=document.createElement('div');
+  frame.className='preview-frame';
+  frame.style.width=`${size.width}px`;
+  frame.style.height=`${size.height}px`;
+  const wrapper=document.createElement('div');
+  wrapper.innerHTML=svg;
+  const node=wrapper.firstChild;
+  if(node){
+    node.setAttribute('width','100%');
+    node.setAttribute('height','100%');
+    node.setAttribute('preserveAspectRatio','xMidYMid meet');
+    node.style.width='100%';
+    node.style.height='100%';
+    frame.appendChild(node);
+  }
+  preview.appendChild(frame);
+  currentAnimationMetaBase='';
+  updateAnimationMetaText();
+  updatePreviewToggle();
+}
+
+function getPreviewFrames(){
+  if(!mediaSource || !mediaSource.frames || !mediaSource.frames.length) return null;
+  if(mediaSource.type==='animation' && mediaSource.preview && mediaSource.preview.frames && mediaSource.preview.frames.length){
+    return mediaSource.preview.frames;
+  }
+  return mediaSource.frames;
+}
+
+function getFrameDelays(frames){
+  if(!frames || !frames.length) return [];
+  return frames.map(frame=>Math.max(10, Math.round(frame.delay||100)));
+}
+
+function sumDelays(delays){
+  if(!delays || !delays.length) return 0;
+  return delays.reduce((sum,value)=>sum+Math.max(0, Math.round(value||0)),0);
+}
+
+function renderFramesToSVGs(frames, options){
+  const svgs=[];
+  let size={w:1,h:1};
+  if(!frames || !frames.length) return {svgs,size};
+  for(const frame of frames){
+    const result=processFrame(frame.canvas, options);
+    svgs.push(result.svg);
+    size=result.size;
+  }
+  return {svgs,size};
+}
+
+function prepareAnimationExport(){
+  if(!mediaSource || mediaSource.type!=='animation' || !mediaSource.frames || !mediaSource.frames.length){
+    throw new Error('Nessuna animazione disponibile');
+  }
+  const options = collectRenderOptions();
+  const {svgs,size} = renderFramesToSVGs(mediaSource.frames, options);
+  const delays = getFrameDelays(mediaSource.frames);
+  return {svgs, delays, size};
+}
+
+function renderAnimationPreview(animation, scale=1){
+  resetAnimationPreview();
+  preview.innerHTML='';
+  currentPreviewAnimation=null;
+  currentPreviewImage=null;
+  currentPreviewDelays=[];
+  if(!animation || !animation.svgs || !animation.svgs.length){
+    currentAnimationMetaBase='';
+    updateAnimationMetaText();
+    updatePreviewToggle();
+    return;
+  }
+  const size = computePreviewSize(scale);
+  const frame=document.createElement('div');
+  frame.className='preview-frame';
+  frame.style.width=`${size.width}px`;
+  frame.style.height=`${size.height}px`;
+  const img=document.createElement('img');
+  img.alt='Anteprima animazione';
+  img.decoding='async';
+  img.draggable=false;
+  img.style.width='100%';
+  img.style.height='100%';
+  frame.appendChild(img);
+  preview.appendChild(frame);
+
+  const delays = animation.delays && animation.delays.length ? animation.delays : new Array(animation.svgs.length).fill(100);
+  const totalDuration = animation.duration || delays.reduce((a,b)=>a+b,0);
+
+  currentPreviewAnimation=animation;
+  currentPreviewImage=img;
+  currentPreviewDelays=delays;
+  animationFrameIndex=0;
+  updatePreviewImage(animationFrameIndex);
+
+  const qualityNote = animation.lowQuality ? ' · Anteprima a bassa qualità' : '';
+  const originalInfo = (mediaSource && mediaSource.width && mediaSource.height && (mediaSource.width!==lastSize.w || mediaSource.height!==lastSize.h))
+    ? ` · Origine ${mediaSource.width}×${mediaSource.height}px`
+    : '';
+  currentAnimationMetaBase=`${lastSize.w}×${lastSize.h}px · ${animation.svgs.length} fotogrammi · ${(totalDuration/1000).toFixed(2)}s${originalInfo}${qualityNote}`;
+  updateAnimationMetaText();
+  updatePreviewToggle();
+
+  if(previewPlaying && animation.svgs.length>1){
+    schedulePreviewAdvance();
+  }
+}
+
+function updatePreviewImage(index){
+  if(!currentPreviewAnimation || !currentPreviewImage || !currentPreviewAnimation.svgs || !currentPreviewAnimation.svgs.length) return;
+  const frames=currentPreviewAnimation.svgs;
+  const safeIndex=((index%frames.length)+frames.length)%frames.length;
+  const svg=frames[safeIndex];
+  currentPreviewImage.src='data:image/svg+xml;charset=utf-8,'+encodeURIComponent(svg);
+}
+
+function schedulePreviewAdvance(){
+  if(animationTimer){
+    clearTimeout(animationTimer);
+    animationTimer=null;
+  }
+  if(!previewPlaying || !currentPreviewAnimation || !currentPreviewImage) return;
+  if(!currentPreviewAnimation.svgs || currentPreviewAnimation.svgs.length<=1) return;
+  const delays = currentPreviewDelays && currentPreviewDelays.length ? currentPreviewDelays : new Array(currentPreviewAnimation.svgs.length).fill(100);
+  const delayIndex = animationFrameIndex < delays.length ? animationFrameIndex : 0;
+  const waitTime = Math.max(16, delays[delayIndex] || delays[0] || 100);
+  animationTimer=setTimeout(()=>{
+    animationFrameIndex=(animationFrameIndex+1)%currentPreviewAnimation.svgs.length;
+    updatePreviewImage(animationFrameIndex);
+    schedulePreviewAdvance();
+  }, waitTime);
+}
+
+function updateAnimationMetaText(){
+  if(!meta) return;
+  if(currentAnimationMetaBase){
+    const pauseNote = (!previewPlaying && currentPreviewAnimation && currentPreviewAnimation.svgs && currentPreviewAnimation.svgs.length>1) ? ' · Anteprima in pausa' : '';
+    meta.textContent=`${currentAnimationMetaBase}${pauseNote}`;
+  }else if(lastSize && lastSize.w && lastSize.h){
+    meta.textContent=`${lastSize.w}×${lastSize.h}px`;
+  }else{
+    meta.textContent='';
+  }
+}
+
+function updatePreviewToggle(){
+  if(!previewToggle) return;
+  const hasAnimation = !!(lastAnimation && lastAnimation.svgs && lastAnimation.svgs.length>1);
+  previewToggle.hidden = !hasAnimation;
+  previewToggle.setAttribute('aria-hidden', hasAnimation ? 'false' : 'true');
+  previewToggle.disabled = !hasAnimation;
+  previewToggle.setAttribute('aria-disabled', (!hasAnimation).toString());
+  if(!hasAnimation){
+    previewToggle.textContent='RIPRODUCI ANTEPRIMA';
+    return;
+  }
+  previewToggle.textContent = previewPlaying ? 'PAUSA ANTEPRIMA' : 'RIPRODUCI ANTEPRIMA';
+}
+
+function setPreviewPlaying(playing){
+  const next=!!playing;
+  if(previewPlaying===next){
+    if(next && !animationTimer) schedulePreviewAdvance();
+    updatePreviewToggle();
+    updateAnimationMetaText();
+    return;
+  }
+  previewPlaying=next;
+  if(!previewPlaying){
+    resetAnimationPreview(false);
+  }else if(currentPreviewAnimation && currentPreviewAnimation.svgs && currentPreviewAnimation.svgs.length>1){
+    schedulePreviewAdvance();
+  }
+  updatePreviewToggle();
+  updateAnimationMetaText();
+}
+
+let resizeRaf=null;
+window.addEventListener('resize',()=>{
+  const hasAnimation = lastAnimation && lastAnimation.svgs && lastAnimation.svgs.length;
+  if(!hasAnimation && !lastSVG) return;
+  if(resizeRaf) cancelAnimationFrame(resizeRaf);
+  resizeRaf=requestAnimationFrame(()=>{
+    resizeRaf=null;
+    const scale=parseFloat(el.scale.value||'1');
+    if(hasAnimation){
+      renderAnimationPreview(lastAnimation, scale);
+    }else{
+      renderStaticPreview(lastSVG, scale);
+    }
+  });
+});
+
+// EXPORT
+const svgBtn=$('dlSVG');
+if(svgBtn){
+  svgBtn.addEventListener('click',()=>{
+    const svgSource = (lastAnimation && lastAnimation.svgs && lastAnimation.svgs.length) ? lastAnimation.svgs[0] : lastSVG;
+    if(!svgSource) return;
+    const blob=new Blob([svgSource],{type:'image/svg+xml'});
+    triggerDownload(blob,'bitmap.svg');
+  });
+}
+
+const pngBtn=$('dlPNG');
+if(pngBtn){
+  pngBtn.addEventListener('click',async()=>{
+    const svgSource = (lastAnimation && lastAnimation.svgs && lastAnimation.svgs.length) ? lastAnimation.svgs[0] : lastSVG;
+    if(!svgSource) return;
+    try{
+      const dims=getExportDimensions();
+      const canvas=await svgToCanvas(svgSource,dims.width,dims.height, el.rasterBG ? el.rasterBG.value : '#ffffff');
+      const blob=await canvasToBlob(canvas,'image/png');
+      triggerDownload(blob,'bitmap.png');
+    }catch(err){ console.error(err); }
+  });
+}
+
+const jpgBtn=$('dlJPG');
+if(jpgBtn){
+  jpgBtn.addEventListener('click',async()=>{
+    const svgSource = (lastAnimation && lastAnimation.svgs && lastAnimation.svgs.length) ? lastAnimation.svgs[0] : lastSVG;
+    if(!svgSource) return;
+    try{
+      const dims=getExportDimensions();
+      const canvas=await svgToCanvas(svgSource,dims.width,dims.height, el.rasterBG ? el.rasterBG.value : '#ffffff');
+      const quality=parseFloat(el.jpegQ.value||'0.9');
+      const blob=await canvasToBlob(canvas,'image/jpeg', Math.min(0.95, Math.max(0.6, quality||0.9)));
+      triggerDownload(blob,'bitmap.jpg');
+    }catch(err){ console.error(err); }
+  });
+}
+
+const gifBtn=$('dlGIF');
+if(gifBtn){
+  gifBtn.addEventListener('click',async()=>{
+    if(!lastAnimation || !lastAnimation.svgs || !lastAnimation.svgs.length) return;
+    await runAnimationExport(gifBtn,'ESPORTO GIF…',async()=>{
+      const blob=await exportAnimatedGIF();
+      if(blob) triggerDownload(blob,'bitmap.gif');
+    });
+  });
+}
+
+const videoBtn=$('dlMP4');
+if(videoBtn){
+  videoBtn.addEventListener('click',async()=>{
+    if(!lastAnimation || !lastAnimation.svgs || !lastAnimation.svgs.length) return;
+    await runAnimationExport(videoBtn,'ESPORTO VIDEO…',async()=>{
+      const result=await exportAnimatedVideo();
+      if(!result) return;
+      const {blob,mime}=result;
+      const ext = mime.includes('mp4') ? 'mp4' : (mime.includes('webm') ? 'webm' : 'mp4');
+      triggerDownload(blob,`bitmap.${ext}`);
+    });
+  });
+}
 
 // initial render
 fastRender();

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,31 +1,55 @@
 
 :root{--bg:#fff;--fg:#000;--line:#000;--muted:#666}
 *{box-sizing:border-box}
-html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:JetBrains Mono,monospace}
+html,body{height:100%;margin:0;background:var(--bg);color:var(--fg);font-family:JetBrains Mono,monospace;overflow:hidden}
 .topbar{height:56px;display:flex;align-items:center;padding:0 12px;border-bottom:1px solid var(--line);font-weight:700}
-.layout{display:flex;min-height:calc(100vh - 56px);gap:0}
-.preview-area{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;padding:8px}
-.preview-box{width:100%;max-width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:#fff;border-right:1px solid var(--line);overflow:auto;padding:8px}
-#preview svg,#preview img{max-width:100%;height:auto;image-rendering:pixelated}
-.controls-panel{width:380px;border-left:1px solid var(--line);display:flex;flex-direction:column;gap:8px;padding:8px;background:#fff}
-.controls-top{display:none;gap:8px}
-.mobile-file{display:none}
-.dropzone{display:none}
-.controls-body{overflow:auto;padding:4px;}
+.layout{display:flex;height:calc(100vh - 56px);gap:0;overflow:hidden}
+.preview-area{flex:1;display:flex;flex-direction:column;align-items:stretch;justify-content:flex-start;padding:8px;min-height:0;gap:8px}
+.preview-box{flex:1;min-height:0;width:100%;max-width:100%;display:flex;align-items:center;justify-content:center;background:#fff;border-right:1px solid var(--line);overflow:hidden;padding:8px}
+#preview .preview-frame{display:flex;align-items:center;justify-content:center;max-width:100%;max-height:100%;}
+#preview svg,#preview img{width:100%;height:100%;max-width:100%;max-height:100%;image-rendering:pixelated}
+.preview-footer{display:flex;align-items:center;justify-content:space-between;gap:8px}
+.preview-footer .meta{flex:1;min-width:0}
+.preview-toggle{padding:8px 14px;border:1px solid var(--line);border-radius:8px;background:var(--bg);font-weight:600;text-transform:uppercase;font-size:11px;letter-spacing:.06em;cursor:pointer;transition:background .2s,border-color .2s,color .2s}
+.preview-toggle:hover:not([disabled]){background:#f0f0f0}
+.preview-toggle[disabled]{opacity:0.5;cursor:not-allowed}
+.controls-panel{width:380px;border-left:1px solid var(--line);display:flex;flex-direction:column;gap:8px;padding:8px;background:#fff;min-height:0;overflow:hidden}
+.controls-top{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:4px}
+.file-btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border:1px solid var(--line);border-radius:8px;font-weight:600;cursor:pointer;background:var(--bg);transition:background .2s,border-color .2s,color .2s;text-transform:uppercase;font-size:12px;letter-spacing:.06em}
+.file-btn:hover{background:#f0f0f0}
+.file-btn input{position:absolute;inset:0;opacity:0;cursor:pointer}
+.primary-file{min-width:160px}
+.mobile-only{display:none}
+.dropzone{flex:1 1 220px;display:flex;align-items:center;justify-content:center;border:1px dashed var(--line);padding:12px;border-radius:8px;text-align:center;font-weight:600;text-transform:uppercase;font-size:12px;letter-spacing:.06em;cursor:pointer;transition:background .2s,border-color .2s}
+.dropzone:hover,.dropzone:focus-visible{outline:none;background:#f0f0f0;border-color:#333}
+.dropzone.is-dragover{background:#e6f3ff;border-color:#1a73e8}
+.upload-feedback{flex:1 1 100%;display:flex;flex-direction:column;gap:4px;font-size:11px;letter-spacing:.05em;text-transform:uppercase}
+.upload-message{font-weight:600;word-break:break-word}
+.upload-progress{position:relative;width:100%;height:6px;background:#e6e6e6;border-radius:999px;overflow:hidden}
+.upload-progress[hidden]{display:none}
+.upload-progress .progress-bar{position:absolute;inset:0 auto 0 0;height:100%;width:0;background:#1a73e8;transition:width .2s ease}
+.upload-progress.is-indeterminate .progress-bar{width:40%;animation:uploadPulse 1.2s infinite ease-in-out}
+@keyframes uploadPulse{0%{margin-left:-40%}50%{margin-left:20%}100%{margin-left:100%}}
+.controls-body{flex:1;overflow:auto;padding:4px;min-height:0}
 .field{margin-bottom:10px;display:flex;flex-direction:column;gap:6px}
 .slider{display:flex;gap:8px;align-items:center}
 .slider input[type='range']{flex:1;height:2px;background:#000;border-radius:4px}
 .num{width:80px;padding:6px;border:1px solid var(--line);border-radius:8px}
-.btn-row{display:flex;gap:8px}
+.btn-row{display:flex;gap:8px;flex-wrap:wrap}
+.btn-row + .btn-row{margin-top:6px}
+.btn-row button[disabled]{opacity:0.5;cursor:not-allowed}
 hr{border:0;border-top:1px solid #eee;margin:8px 0}
 .muted{color:var(--muted);font-size:12px}
 @media (max-width:900px){
   .layout{flex-direction:column}
-  .controls-panel{width:100%;order:2;border-left:0;border-top:1px solid var(--line);padding:6px}
-  .preview-area{order:1;padding:6px}
-  .controls-top{display:flex}
-  .mobile-file{display:inline-block}
-  .dropzone{display:block;border:1px dashed var(--line);padding:8px;border-radius:8px;text-align:center}
-  .controls-body{display:flex;gap:8px;overflow-x:auto;padding:8px;flex-wrap:nowrap}
+  .controls-panel{width:100%;order:2;border-left:0;border-top:1px solid var(--line);padding:6px;flex:1 1 50%}
+  .preview-area{order:1;padding:6px;flex:1 1 50%}
+  .preview-footer{flex-direction:column;align-items:flex-start;gap:6px}
+  .preview-toggle{width:100%}
+  .mobile-only{display:inline-flex}
+  .file-btn{width:100%}
+  .dropzone{display:none}
+  .upload-feedback{order:4;font-size:12px;text-transform:none;letter-spacing:0}
+  .controls-body{display:flex;gap:8px;overflow:auto;padding:8px;flex-wrap:nowrap}
   .field{min-width:220px;flex:0 0 auto}
 }


### PR DESCRIPTION
## Summary
- add an animation preview play/pause control with stateful messaging so heavy uploads can be paused without losing context
- keep the UI responsive during GIF/MP4 exports by processing frames sequentially, throttling MediaRecorder writes, and disabling export buttons while work is in progress
- refresh styling to house the new preview controls across desktop and mobile layouts

## Testing
- node --check src/app.js

------
https://chatgpt.com/codex/tasks/task_e_68e4b8c40940833295a38ff0d020a77f